### PR TITLE
Migrate to building on for core20

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,10 +12,10 @@ description: |
 confinement: strict
 grade: stable
 architectures: [amd64]
+base: core20
 
 parts:
   tarball:
-    after: [desktop-gtk3]
     plugin: dump
     source: http://www.bay12games.com/dwarves/df_47_05_linux.tar.bz2
     source-checksum: sha512/9ea46fa12a80266cd09363f1aea8cdd059a5ebeefb453c4a46ffbb1115486409003c3caca95a1b6010da4040d04b781182c59e57a6cc033cd7de4507299f7534
@@ -42,5 +42,6 @@ parts:
 
 apps:
   dwarffortress:
-    command: desktop-launch $SNAP/wrapper.sh
-    plugs: [opengl, pulseaudio, x11, unity7]
+    extensions: [gnome-3-38]
+    command: wrapper.sh
+    plugs: [opengl, audio-playback, x11, unity7]


### PR DESCRIPTION
This PR updates the snap build configuration. Previously with no base specified it was building against an older Ubuntu base of 16.04. By specifying core20 as the base, we get newer packages to build with, including the new GNOME extension which simplifies the parts, and makes the snap a little smaller and faster to start. The newer base also triggers newer code path in snapcraft.

I tested this on my local machine. All works as expected.

The only regression from doing this is that you'll no longer get i386 builds as i386 is no longer supported on Ubuntu 20.04 (the base from which core20 derives). If that's important we could go to core18 instead.

To build locally you must use `snapcraft` with `--enable-experimental-extensions`. This will land in `snapcraft` stable soon (end of the week I am told) so there will be no need for that experimental parameter, and will allow this to build in launchpad or the snapcraft build service. I'll keep this PR as draft until then.