### PR TITLE
Add missing libcurses5 to support PRINT_MODE:TEXT

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,6 +31,8 @@ parts:
       - gtk2-engines-pixbuf
       - libcanberra-gtk-module
       - libglu1-mesa
+      - libncurses5
+      - libncursesw5
       - libopenal1
       - libsdl-image1.2
       - libsdl-ttf2.0-0


### PR DESCRIPTION
Without this, you get an error about libcurses5 not being found, and installing it at the system level doesn't seem to help.